### PR TITLE
Pulire e deployare sito statico su GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,50 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
     <meta property="og:url" content="https://intraspecificselection.pyragogy.org/" />
     <meta property="og:title" content="Cognitive Intraspecific Selection in Education | Revolutionary Educational Framework" />
     <meta property="og:description" content="Groundbreaking research by Fabrizio Terzi presenting a novel framework that transposes biological evolution to educational contexts, introducing Pyragogy methodology." />
-    <meta property="og:image" content="/logo-full.png" />
+    <meta property="og:image" content="./logo-full.png" />
     <meta property="og:site_name" content="Pyragogy Research" />
     <meta property="article:author" content="Fabrizio Terzi" />
     <meta property="article:published_time" content="2024-09-01" />
@@ -29,14 +29,14 @@
     <meta property="twitter:url" content="https://intraspecificselection.pyragogy.org/" />
     <meta property="twitter:title" content="Cognitive Intraspecific Selection in Education" />
     <meta property="twitter:description" content="Framework for educational evolution and collective intelligence building by Fabrizio Terzi" />
-    <meta property="twitter:image" content="/logo-full.png" />
+    <meta property="twitter:image" content="./logo-full.png" />
     <meta property="twitter:creator" content="@Pyragogy" />
     
     <!-- Academic Meta Tags -->
     <meta name="citation_title" content="Cognitive Intraspecific Selection in Education: From Individualism to Collective Strength" />
     <meta name="citation_author" content="Terzi, Fabrizio" />
     <meta name="citation_publication_date" content="2024" />
-    <meta name="citation_pdf_url" content="https://intraspecificselection.pyragogy.org/Cognitive_Intraspecific_Selection_EN.pdf" />
+    <meta name="citation_pdf_url" content="./Cognitive_Intraspecific_Selection_EN.pdf" />
     
     <!-- Structured Data -->
     <script type="application/ld+json">

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="refresh" content="0; url=./" />
+    <meta name="robots" content="noindex" />
+    <title>Redirecting…</title>
+    <style>
+      body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji"; padding: 2rem; text-align: center; color: #444; }
+    </style>
+  </head>
+  <body>
+    <p>Redirecting to the homepage…</p>
+    <script>
+      (function() {
+        var l = window.location;
+        // If meta refresh is blocked, fallback to JS redirect to directory root
+        var path = l.pathname;
+        var base = path.endsWith('/') ? path : path.replace(/[^/]*$/, '');
+        if (!/\/$/.test(base)) base += '/';
+        l.replace(base);
+      })();
+    </script>
+  </body>
+</html>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,16 +1,16 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
-import { BrowserRouter as Router } from 'react-router-dom'
+import { BrowserRouter } from 'react-router-dom'
 import { ThemeProvider } from "next-themes"
 import App from './App.tsx'
 import './index.css'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <Router>
+    <BrowserRouter basename={import.meta.env.BASE_URL}>
       <ThemeProvider defaultTheme="dark" storageKey="vite-ui-theme">
           <App />
       </ThemeProvider>
-    </Router>
+    </BrowserRouter>
   </React.StrictMode>
 )

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -20,6 +20,7 @@ import logoFull from '/logo-full.png';
 const IndexPage = () => {
   const [activeSection, setActiveSection] = useState('');
   const { toast } = useToast();
+  const pdfUrl = `${import.meta.env.BASE_URL}Cognitive_Intraspecific_Selection_EN.pdf`;
 
   const keyPoints = [
     {
@@ -197,7 +198,7 @@ const IndexPage = () => {
                 
                 <div className="flex flex-wrap gap-4 pt-4">
                   <Button asChild size="lg" className="bg-gradient-primary hover:shadow-glow transition-all duration-500 px-8 py-6 text-lg rounded-2xl group hover:scale-105 active:scale-95 font-semibold">
-                    <a href="/Cognitive_Intraspecific_Selection_EN.pdf" target="_blank" rel="noopener" download>
+                    <a href={pdfUrl} target="_blank" rel="noopener" download>
                       <Download className="w-5 h-5 mr-2 group-hover:animate-bounce transition-all duration-300" />
                       Download Full Thesis
                     </a>
@@ -437,7 +438,7 @@ const IndexPage = () => {
                   Complete 120-page academic thesis with comprehensive analysis and practical applications.
                 </p>
                 <Button asChild className="w-full bg-gradient-primary hover:shadow-glow transition-all duration-300">
-                  <a href="/Cognitive_Intraspecific_Selection_EN.pdf" target="_blank" rel="noopener" download>
+                  <a href={pdfUrl} target="_blank" rel="noopener" download>
                     <Download className="w-4 h-4 mr-2" />
                     Download PDF
                   </a>
@@ -486,8 +487,8 @@ const IndexPage = () => {
         <footer className="py-20 bg-gradient-to-br from-muted/10 to-background border-t">
           <div className="container mx-auto px-4">
             <div className="text-center space-y-8">
-              <div className="flex items-center justify-center gap-4 mb-8">
-                <img src="/logo-full.png" alt="Pyragogy.org" className="h-12 w-auto" />
+                <div className="flex items-center justify-center gap-4 mb-8">
+                <img src={logoFull} alt="Pyragogy.org" className="h-12 w-auto" />
                 <span className="text-2xl font-serif font-bold">Pyragogy Research</span>
               </div>
               
@@ -501,7 +502,7 @@ const IndexPage = () => {
                   </a>
                 </Button>
                 <Button asChild variant="outline" className="glass hover:bg-primary/5">
-                  <a href="/Cognitive_Intraspecific_Selection_EN.pdf" target="_blank" rel="noopener" download>
+                  <a href={pdfUrl} target="_blank" rel="noopener" download>
                     <Download className="w-4 h-4 mr-2" />
                     Download Thesis
                   </a>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,19 +1,32 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import path from "path";
+import fs from "fs";
 import { componentTagger } from "lovable-tagger";
 
 // https://vitejs.dev/config/
-export default defineConfig(({ mode }) => ({
-  base: '/',
-  server: {
-    host: "::",
-    port: 8080,
-  },
-  plugins: [react(), mode === "development" && componentTagger()].filter(Boolean),
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./src"),
+export default defineConfig(({ mode }) => {
+  // If a custom domain CNAME is present, deploy will be at domain root
+  const hasCustomDomain = fs.existsSync(path.resolve(__dirname, "public/CNAME"))
+    && fs.readFileSync(path.resolve(__dirname, "public/CNAME"), "utf8").trim().length > 0;
+
+  // When building on GitHub Actions without a CNAME, default base to repo name
+  const repoName = process.env.GITHUB_REPOSITORY?.split("/")[1] ?? "";
+  const computedBase = hasCustomDomain
+    ? "/"
+    : (mode === "production" && repoName ? `/${repoName}/` : "/");
+
+  return {
+    base: computedBase,
+    server: {
+      host: "::",
+      port: 8080,
     },
-  },
-}));
+    plugins: [react(), mode === "development" && componentTagger()].filter(Boolean),
+    resolve: {
+      alias: {
+        "@": path.resolve(__dirname, "./src"),
+      },
+    },
+  };
+});


### PR DESCRIPTION
Configure the project for GitHub Pages deployment by adjusting base paths, routing, asset references, and adding an automated deployment workflow.

This PR resolves issues where absolute paths and client-side routing would break when the Vite/React SPA is deployed to a subpath on GitHub Pages (e.g., `username.github.io/repo-name/`). It ensures correct asset loading, client-side routing via `BrowserRouter` with `basename`, and provides a `404.html` for SPA fallbacks, along with a GitHub Actions workflow for automated builds and deployments.

---
<a href="https://cursor.com/background-agent?bcId=bc-8407014a-ac61-4daf-88e4-9a713e93247f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8407014a-ac61-4daf-88e4-9a713e93247f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

